### PR TITLE
fix: aave error handling

### DIFF
--- a/data/aave.ts
+++ b/data/aave.ts
@@ -2,6 +2,7 @@ import { FeeData } from './feeData';
 
 const fetcher = async (input: RequestInfo, init?: RequestInit) => {
   const res = await fetch(input, init);
+  if (res.status !== 200) throw new Error('aave did return an error');
   return res.json();
 };
 
@@ -10,7 +11,7 @@ export async function getAaveData(): Promise<FeeData> {
   return {
     id: 'aave',
     category: 'app',
-    sevenDayMA: parseFloat(response.last7DaysUTCAvg),
-    oneDay: parseFloat(response.lastDayUTCFees),
+    sevenDayMA: parseFloat(response?.last7DaysUTCAvg),
+    oneDay: parseFloat(response?.lastDayUTCFees),
   };
 }

--- a/data/hegic.ts
+++ b/data/hegic.ts
@@ -67,16 +67,16 @@ export async function getHegicData(): Promise<FeeData> {
     }
   }
 
-  const ethPriceYesterday = await getHistoricalAvgDailyPrice("ethereum", 1);
-  const wbtcPriceYesterday = await getHistoricalAvgDailyPrice("wrapped-bitcoin", 1);
+  const ethPriceYesterday = await getHistoricalAvgDailyPrice('ethereum', 1);
+  const wbtcPriceYesterday = await getHistoricalAvgDailyPrice('wrapped-bitcoin', 1);
 
-  const ethPriceLastWeek = await getHistoricalAvgDailyPrice("ethereum", 7);
-  const wbtcPriceLastWeek = await getHistoricalAvgDailyPrice("wrapped-bitcoin", 7);
+  const ethPriceLastWeek = await getHistoricalAvgDailyPrice('ethereum', 7);
+  const wbtcPriceLastWeek = await getHistoricalAvgDailyPrice('wrapped-bitcoin', 7);
 
   // calculate total fees in USD over the past 24h hours
-  const totalFeesYesterday = (ethFeesYesterday * ethPriceYesterday) + (wbtcFeesYesterday * wbtcPriceYesterday);
-  const totalFeesWeek = (ethFeesWeek * ethPriceLastWeek) + (wbtcFeesWeek * wbtcPriceLastWeek);
-
+  const totalFeesYesterday =
+    ethFeesYesterday * ethPriceYesterday + wbtcFeesYesterday * wbtcPriceYesterday;
+  const totalFeesWeek = ethFeesWeek * ethPriceLastWeek + wbtcFeesWeek * wbtcPriceLastWeek;
 
   return {
     id: 'hegic',

--- a/data/pricedata.ts
+++ b/data/pricedata.ts
@@ -12,9 +12,12 @@ export const getCurrentPrice = async (name: string): Promise<number> => {
   return priceCache[name];
 };
 
-export const getHistoricalAvgDailyPrice = async (name: string, daysAgo: number): Promise<number> => {
+export const getHistoricalAvgDailyPrice = async (
+  name: string,
+  daysAgo: number
+): Promise<number> => {
   let cacheName = name;
-  if (daysAgo > 1 && name != "usd") {
+  if (daysAgo > 1 && name != 'usd') {
     cacheName += daysAgo;
   }
 
@@ -23,11 +26,11 @@ export const getHistoricalAvgDailyPrice = async (name: string, daysAgo: number):
       `https://api.coingecko.com/api/v3/coins/${name}/market_chart?vs_currency=usd&days=${daysAgo}&interval=daily`
     );
     const response = await request.json();
-    let prices = response.prices;
+    const prices = response.prices;
     prices.pop(); // remove last element, which is today's price
 
     let cumulativePrice = 0;
-    for (let price of prices) {
+    for (const price of prices) {
       cumulativePrice += price[1];
     }
 

--- a/data/tbtc.ts
+++ b/data/tbtc.ts
@@ -29,23 +29,25 @@ export async function getTBTCData(): Promise<FeeData> {
     'fees'
   );
 
-  const ethPriceYesterday = await getHistoricalAvgDailyPrice("ethereum", 1);
-  const wbtcPriceYesterday = await getHistoricalAvgDailyPrice("wrapped-bitcoin", 1);
+  const ethPriceYesterday = await getHistoricalAvgDailyPrice('ethereum', 1);
+  const wbtcPriceYesterday = await getHistoricalAvgDailyPrice('wrapped-bitcoin', 1);
 
-  const ethPriceLastWeek = await getHistoricalAvgDailyPrice("ethereum", 7);
-  const wbtcPriceLastWeek = await getHistoricalAvgDailyPrice("wrapped-bitcoin", 7);
+  const ethPriceLastWeek = await getHistoricalAvgDailyPrice('ethereum', 7);
+  const wbtcPriceLastWeek = await getHistoricalAvgDailyPrice('wrapped-bitcoin', 7);
 
   const oneDayTBTCFees = (parseInt(data.now.tbtcFees) - parseInt(data.yesterday.tbtcFees)) / 1e18;
   const oneDayTBTCFeesInUSD = oneDayTBTCFees * wbtcPriceYesterday;
 
-  const oneDayBeaconFees = (parseInt(data.now.randomBeaconFees) - parseInt(data.yesterday.randomBeaconFees)) / 1e18;
+  const oneDayBeaconFees =
+    (parseInt(data.now.randomBeaconFees) - parseInt(data.yesterday.randomBeaconFees)) / 1e18;
   const oneDayBeaconFeesInUSD = oneDayBeaconFees * ethPriceYesterday;
 
   const oneWeekTBTCFees = (parseInt(data.now.tbtcFees) - parseInt(data.weekAgo.tbtcFees)) / 1e18;
-  const oneWeekTBTCFeesInUSD = oneWeekTBTCFees * wbtcPriceLastWeek / 7;
+  const oneWeekTBTCFeesInUSD = (oneWeekTBTCFees * wbtcPriceLastWeek) / 7;
 
-  const oneWeekBeaconFees = (parseInt(data.now.randomBeaconFees) - parseInt(data.weekAgo.randomBeaconFees)) / 1e18;
-  const oneWeekBeaconFeesInUSD = oneWeekBeaconFees * ethPriceLastWeek / 7;
+  const oneWeekBeaconFees =
+    (parseInt(data.now.randomBeaconFees) - parseInt(data.weekAgo.randomBeaconFees)) / 1e18;
+  const oneWeekBeaconFeesInUSD = (oneWeekBeaconFees * ethPriceLastWeek) / 7;
 
   return {
     id: 'tbtc',


### PR DESCRIPTION
I didn't realize that fetch doesn't throw on 500 :/ - this caused ~1min downtime.
Sorry for that, this improvement should protect from issues like that in the future.