### PR TITLE
Update polymarket subgraph url to use graph hosted service

### DIFF
--- a/data/polymarket.ts
+++ b/data/polymarket.ts
@@ -3,7 +3,7 @@ import { getBlockDaysAgo, CHAIN } from './time-lib';
 
 export async function getPolymarketData(): Promise<FeeData> {
   const request = await fetch(
-    'https://subgraph-matic.poly.market/subgraphs/name/TokenUnion/polymarket',
+    'https://api.thegraph.com/subgraphs/name/tokenunion/polymarket-matic',
     {
       headers: {
         'content-type': 'application/json',


### PR DESCRIPTION
Now that the Graph supports matic we've moved over to using the hosted service for our subgraphs. We'll be switching our old nodes off in the near future.