### PR TITLE
fix: use correct timestamps

### DIFF
--- a/data/adapters/ren.ts
+++ b/data/adapters/ren.ts
@@ -6,8 +6,8 @@ const ONE_DAY = 86400;
 
 export default function registerRen(register: RegisterFunction) {
   async function getRenData(date: string): Promise<number> {
-    const snapshotTimestamp = dateToTimestamp(date);
-    const dayBeforeSnapshotTimestamp = snapshotTimestamp - ONE_DAY;
+    const snapshotTimestamp = dateToTimestamp(date) + ONE_DAY;
+    const dayBeforeSnapshotTimestamp = snapshotTimestamp;
     // console.log({ now, oneDayAgo })
 
     const req = await fetch('https://stats.renproject.io/', {


### PR DESCRIPTION
noticed an error in #42 and think ren adapter is doing the exact same mistake